### PR TITLE
Fix bool code example typo

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1193,7 +1193,7 @@ Example:
   stdout > @
     sprintf
       "%b\n%b\n"
-      TREU
+      TRUE
       FALSE
 \end{ffcode}
 \textbf{Output}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing a typo in the `book.tex` file. 

### Detailed summary:
- Fixed a typo by changing `TREU` to `TRUE` in the `sprintf` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->